### PR TITLE
nettrace: add support to print bpf debug info

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Usage:
 
     -v               show log information
     --debug          show debug information
+    --bpf-debug      show bpf debug information
     -h, --help       show help information
 ```
 

--- a/common.mk
+++ b/common.mk
@@ -53,7 +53,7 @@ $(error kernel headers not exist in COMPAT mdoe, please install it)
 endif
 	kheaders_cmd	:= ln -s vmlinux_header.h kheaders.h
 	CFLAGS		+= -DCOMPAT_MODE
-	BPF_CFLAGS	+= $(KERNEL_CFLAGS)
+	BPF_CFLAGS	+= $(KERNEL_CFLAGS) -DBPF_NO_GLOBAL_DATA
 else
 	kheaders_cmd	:= ln -s ../shared/bpf/vmlinux.h kheaders.h
 endif
@@ -68,6 +68,10 @@ else
 	BPFTOOL		:= $(ROOT)/script/bpftool-arm
 endif
 endif
+endif
+
+ifdef BPF_DEBUG
+	CFLAGS		+= -DBPF_DEBUG
 endif
 
 kheaders.h:

--- a/script/bash-completion.sh
+++ b/script/bash-completion.sh
@@ -1,2 +1,2 @@
-complete -W '-s --saddr --saddr6 -d --daddr --daddr6 --addr --addr6 -p -D --dport -S --sport -P --port --pid -t --trace -v --detail --debug --ret --basic --diag --diag-quiet --diag-keep --date --drop --drop-stack --hooks -h --help' nettrace
+complete -W '-s --saddr --saddr6 -d --daddr --daddr6 --addr --addr6 -p -D --dport -S --sport -P --port --pid -t --trace -v --detail --debug --bpf-debug --ret --basic --diag --diag-quiet --diag-keep --date --drop --drop-stack --hooks -h --help' nettrace
 complete -W '-h -s -d --addr -p --dport --sport --port -t -v --detail --stack --stack-tracer --timeline -c --ret --skb-mode --force-stack --tcp-flags -o --output' nettrace-legacy

--- a/shared/bpf/skb_shared.h
+++ b/shared/bpf/skb_shared.h
@@ -52,6 +52,7 @@ typedef struct __attribute__((__packed__)) {
 #define TCP_FLAGS_RST	(1 << 2)
 #define TCP_FLAGS_SYN	(1 << 1)
 
+/* used for packet filter condition */
 typedef struct {
 	u32	saddr;
 	bool	enable_saddr;

--- a/shared/bpf_utils.h
+++ b/shared/bpf_utils.h
@@ -11,6 +11,9 @@
 
 typedef struct {
 	pkt_args_t pkt;
+#ifdef BPF_DEBUG
+	bool bpf_debug;
+#endif
 #ifdef DEFINE_BPF_ARGS
 	DEFINE_BPF_ARGS();
 #endif

--- a/src/nettrace.c
+++ b/src/nettrace.c
@@ -96,6 +96,13 @@ static void do_parse_args(int argc, char *argv[])
 			.type = OPTION_BOOL,
 			.desc = "show debug information",
 		},
+#ifdef BPF_DEBUG
+		{
+			.lname = "bpf-debug", .dest = &bpf_args->bpf_debug,
+			.type = OPTION_BOOL,
+			.desc = "show bpf debug information",
+		},
+#endif
 		{
 			.lname = "help",
 			.sname = 'h',

--- a/src/progs/kprobe.c
+++ b/src/progs/kprobe.c
@@ -97,6 +97,7 @@ static try_inline int handle_entry(void *regs, struct sk_buff *skb,
 	if (!ARGS_GET(ready))
 		return -1;
 
+	pr_debug_skb("begin to handle, func=%d", func);
 	pid = (u32)bpf_get_current_pid_tgid();
 	if (ARGS_GET(trace_mode) & MODE_SKIP_LIFE_MASK) {
 		if (!probe_parse_skb(skb, pkt))
@@ -133,6 +134,7 @@ skip_life:
 	}
 
 out:
+	pr_debug_skb("pkt matched");
 	try_trace_stack(regs, bpf_args, e, func);
 	pkt->ts = bpf_ktime_get_ns();
 	e->key = (u64)(void *)skb;


### PR DESCRIPTION
eBPF program debug info can be printed to /sys/kernel/debug/tracing/trace if BPF_DEBUG=1 is set when compile and --bpf-debug is added when run the nettrace command.

Signed-off-by: Menglong Dong <imagedong@tencent.com>