### PR TITLE
fix: sym_lookup_proc crashed on Linux Kernel 6.2.0-23

### DIFF
--- a/component/parse_sym.h
+++ b/component/parse_sym.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-#define MAX_SYM_LENGTH		128
+#define MAX_SYM_LENGTH		256
 #define MAX_SYM_ADDR_LENGTH	(MAX_SYM_LENGTH + 8)
 
 enum {


### PR DESCRIPTION
As following, parsing sym to cname into crash, Length of cname set to 256 can handle this.

char _cname[MAX_SYM_LENGTH];
		if (fscanf(f, "%llx %*s %s [ %*[^]] ]", &cpc, cname) < 0)

uname -a:
Linux pc1 6.2.0-23-generic #23-Ubuntu SMP PREEMPT_DYNAMIC Wed May 17 16:55:20 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux