### PR TITLE
nettrace: disable preserve_access_index in vmlinux.h

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -6,7 +6,7 @@ COMMON_SHARED	:= $(ROOT)/shared/pkt_utils.c $(COMPONENT)/net_utils.c	\
 CFLAGS		+= -I./ -I$(ROOT)/shared/bpf/
 BPF_CFLAGS	= $(CFLAGS) -Wno-unused-function			\
 		  -Wno-compare-distinct-pointer-types -Wuninitialized	\
-		  -D__TARGET_ARCH_$(SRCARCH)
+		  -D__TARGET_ARCH_$(SRCARCH) -DBPF_NO_PRESERVE_ACCESS_INDEX
 HOST_CFLAGS	= \
 		-lbpf -lelf -lz -O2 -static $(CFLAGS)			\
 		-Wno-deprecated-declarations -DVERSION=$(VERSION)	\
@@ -58,7 +58,7 @@ endif
 	kheaders_cmd	:= ln -s vmlinux_header.h kheaders.h
 	CFLAGS		+= -DCOMPAT_MODE
 	BPF_CFLAGS	+= $(KERNEL_CFLAGS) -DBPF_NO_GLOBAL_DATA \
-			   -DBPF_NO_PRESERVE_ACCESS_INDEX -g
+			   -g
 else
 	kheaders_cmd	:= ln -s ../shared/bpf/vmlinux.h kheaders.h
 	BPF_CFLAGS	+= -target bpf -g

--- a/shared/bpf/vmlinux_arm64.h
+++ b/shared/bpf/vmlinux_arm64.h
@@ -121851,10 +121851,6 @@ enum flow_offload_tuple_dir {
 	FLOW_OFFLOAD_DIR_MAX = 2,
 };
 
-#ifndef BPF_NO_PRESERVE_ACCESS_INDEX
-#pragma clang attribute pop
-#endif
-
 struct nft_pktinfo {
 	struct sk_buff *skb;
 	bool tprot_set;
@@ -122111,10 +122107,6 @@ struct nft_jumpstack {
 	const struct nft_chain *chain;
 	struct nft_rule * const *rules;
 };
-
-#ifndef BPF_NO_PRESERVE_ACCESS_INDEX
-#pragma clang attribute push (__attribute__((preserve_access_index)), apply_to = record)
-#endif
 
 enum nf_tables_msg_types {
 	NFT_MSG_NEWTABLE = 0,

--- a/shared/bpf/vmlinux_x86.h
+++ b/shared/bpf/vmlinux_x86.h
@@ -137614,10 +137614,6 @@ enum flow_offload_tuple_dir {
 	FLOW_OFFLOAD_DIR_MAX = 2,
 };
 
-#ifndef BPF_NO_PRESERVE_ACCESS_INDEX
-#pragma clang attribute pop
-#endif
-
 struct nft_pktinfo {
 	struct sk_buff___2 *skb;
 	bool tprot_set;
@@ -137876,10 +137872,6 @@ struct nft_jumpstack {
 	const struct nft_chain *chain;
 	struct nft_rule * const *rules;
 };
-
-#ifndef BPF_NO_PRESERVE_ACCESS_INDEX
-#pragma clang attribute push (__attribute__((preserve_access_index)), apply_to = record)
-#endif
 
 enum nf_tables_msg_types {
 	NFT_MSG_NEWTABLE = 0,

--- a/src/progs/core.c
+++ b/src/progs/core.c
@@ -448,7 +448,7 @@ DEFINE_KPROBE_INIT(nft_do_chain, nft_do_chain, .arg_count = 2)
 		if (!bpf_core_field_exists(pkt->xt))
 			state = _C((struct nft_pktinfo___new *)pkt, state);
 		else
-			state = _C(&(pkt->xt), state);
+			state = _C(pkt, xt.state);
 	} else {
 		/* don't use CO-RE, as nft may be a module */
 		state = _(pkt->xt.state);

--- a/src/progs/core.c
+++ b/src/progs/core.c
@@ -79,20 +79,20 @@ static try_inline int filter_by_netns(context_t *ctx)
 	if (!netns && !ctx->args->detail)
 		return 0;
 
-	dev = _(skb->dev);
+	dev = _C(skb, dev);
 	if (!dev) {
-		struct sock *sk = _(skb->sk);
+		struct sock *sk = _C(skb, sk);
 		if (!sk)
 			goto no_ns;
-		ns = _(sk->__sk_common.skc_net.net);
+		ns = _C(sk, __sk_common.skc_net.net);
 	} else {
-		ns = _(dev->nd_net.net);
+		ns = _C(dev, nd_net.net);
 	}
 
 	if (!ns)
 		goto no_ns;
 
-	inode = _(ns->ns.inum);
+	inode = _C(ns, ns.inum);
 	if (ctx->args->detail)
 		((detail_event_t *)ctx->e)->netns = inode;
 


### PR DESCRIPTION
The "preserve_access_index" in vmlinux.h makes all probe read CO-RE, but we need to disable CO-RE in some case. Therefore, disable the global CO-RE by adding "-DBPF_NO_PRESERVE_ACCESS_INDEX".

close #34 