### PR TITLE
Verify stackid before obtaining stack information

### DIFF
--- a/src/trace_probe.c
+++ b/src/trace_probe.c
@@ -239,6 +239,12 @@ static void probe_trace_ready()
 #ifdef __F_STACK_TRACE
 static void probe_print_stack(int key)
 {
+	if (key <= 0)
+	{
+		pr_info("Call Stack Error! Invalid stack id:%d.\n", key);
+		return;
+	}
+
 	int map_fd = bpf_map__fd(skel->maps.m_stack);
 	__u64 ip[PERF_MAX_STACK_DEPTH] = {};
 	struct sym_result *sym;

--- a/src/trace_tracing.c
+++ b/src/trace_tracing.c
@@ -225,6 +225,12 @@ static void tracing_trace_ready()
 
 static void tracing_print_stack(int key)
 {
+	if (key <= 0)
+	{
+		pr_info("Call Stack Error! Invalid stack id:%d.\n", key);
+		return;
+	}
+
 	int map_fd = bpf_map__fd(skel->maps.m_stack);
 	__u64 ip[PERF_MAX_STACK_DEPTH] = {};
 	struct sym_result *sym;


### PR DESCRIPTION
    When using nettrace to adapt to different kernels, some kernels'
    bpf_get_stickid will return an invalid stackid, and later nettrace will
    use an invalid stackid to trigger the BPF system call to obtain stack
    information, which fails.

    Verify stackid before triggering BPF system calls to avoid triggering
    invalid system calls