### PR TITLE
rstreason: Add reset reason tracking to nettrace

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@ progs		:= nettrace
 prog-nettrace-origin = \
 		trace.c $(COMMON_SHARED) trace_probe.c trace_tracing.c \
 		analysis.c $(COMPONENT)/parse_sym.c trace_group.c \
-		dropreason.c
+		dropreason.c rstreason.c
 prog-nettrace	= $(prog-nettrace-origin) nettrace.c
 
 ifdef COMPAT

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -136,6 +136,7 @@ DECLARE_ANALYZER(iptable);
 DECLARE_ANALYZER(nf);
 DECLARE_ANALYZER(qdisc);
 DECLARE_ANALYZER(rtt);
+DECLARE_ANALYZER(reset);
 DECLARE_ANALYZER(default);
 
 #define define_pure_event(type, name, data)			\

--- a/src/progs/core.c
+++ b/src/progs/core.c
@@ -716,6 +716,46 @@ DEFINE_KPROBE_INIT(nft_do_chain, nft_do_chain, 2,
 }
 #endif
 
+DEFINE_KPROBE_INIT(tcp_v4_send_reset, tcp_v4_send_reset, 3,
+		   	.sk = ctx_get_arg(ctx, 0),
+			.skb = ctx_get_arg(ctx, 1))
+{
+	struct sock *sk = info_get_arg(info, 0);
+	struct sock_common skc_common = _C(sk, __sk_common);
+	DECLARE_EVENT(reset_event_t, e)
+
+	e->state = skc_common.skc_state;
+	e->reason = (u64)info_get_arg(info, 2);
+
+	return handle_entry_output(info, e);
+}
+
+DEFINE_KPROBE_INIT(tcp_v6_send_reset, tcp_v6_send_reset, 3,
+			.sk = ctx_get_arg(ctx, 0),
+ 			.skb = ctx_get_arg(ctx, 1))
+{
+	struct sock *sk = info_get_arg(info, 0);
+	struct sock_common skc_common = _C(sk, __sk_common);
+	DECLARE_EVENT(reset_event_t, e)
+
+	e->state = skc_common.skc_state;
+	e->reason = (u64)info_get_arg(info, 2);
+
+	return handle_entry_output(info, e);
+}
+
+DEFINE_KPROBE_INIT(tcp_send_active_reset, tcp_send_active_reset, 3,
+			.sk = ctx_get_arg(ctx, 0))
+{
+	struct sock *sk = info_get_arg(info, 0);
+	struct sock_common skc_common = _C(sk, __sk_common);
+	DECLARE_EVENT(reset_event_t, e)
+
+	e->state = skc_common.skc_state;
+	e->reason = (u64)info_get_arg(info, 2);
+
+	return handle_entry_output(info, e);
+}
 
 /*******************************************************************
  * 

--- a/src/progs/shared.h
+++ b/src/progs/shared.h
@@ -125,6 +125,11 @@ DEFINE_EVENT(drop_event_t,
 	event_field(u32, reason)
 )
 
+DEFINE_EVENT(reset_event_t,
+	event_field(unsigned char, state)
+	event_field(u32, reason)
+)
+
 DEFINE_EVENT(nf_event_t,
 	event_field(char, table[8])
 	event_field(char, chain[8])

--- a/src/rstreason.c
+++ b/src/rstreason.c
@@ -1,0 +1,95 @@
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys_utils.h>
+
+#include "rstreason.h"
+
+#define REASON_MAX_COUNT 256
+#define REASON_MAX_LEN 32
+
+static char reset_reasons[REASON_MAX_COUNT][REASON_MAX_LEN] = {};
+static int reset_reason_max;
+static bool reset_reason_inited = false;
+static const char *tcp_state_str[] = {
+    "UNKNOWN",           // 0
+    "TCP_ESTABLISHED",   // 1
+    "TCP_SYN_SENT",      // 2
+    "TCP_SYN_RECV",      // 3
+    "TCP_FIN_WAIT1",     // 4
+    "TCP_FIN_WAIT2",     // 5
+    "TCP_TIME_WAIT",     // 6
+    "TCP_CLOSE",         // 7
+    "TCP_CLOSE_WAIT",    // 8
+    "TCP_LAST_ACK",      // 9
+    "TCP_LISTEN",        // 10
+    "TCP_CLOSING",       // 11
+    "TCP_NEW_SYN_RECV",  // 12
+    "TCP_MAX_STATES"     // 13
+};
+
+/* check if rst reason is supported */
+bool reset_reason_support() 
+{
+	return simple_exec("cat /sys/kernel/debug/tracing/events/tcp/"
+        "tcp_send_reset/format 2>/dev/null | "
+        "grep NOT_SPECIFIED") == 0;
+}
+
+static int parse_reason_enum() 
+{
+    char name[REASON_MAX_LEN];
+    int index = 0;
+    FILE *f;
+    int symbolics_found = 1;
+
+    f = fopen("/sys/kernel/debug/tracing/events/tcp/tcp_send_reset/format", "r");
+
+    if (!f || !fsearch(f, "__print_symbolic")) {
+        if (f)
+            fclose(f);
+        return -1;
+    }
+
+    while (true) {
+        if (symbolics_found == 1 &&
+            fsearch(f, "__print_symbolic")) {
+            symbolics_found++;
+        }
+        
+        if (symbolics_found == 2) {
+            if (!fsearch(f, "{") ||
+                fscanf(f, "%d, \"%31[A-Z_0-9]", &index, name) != 2)
+                break;
+            pr_debug("reset_reason[%d] = %s\n", index, name);
+            strcpy(reset_reasons[index], name);
+        } else if (feof(f)) {
+            fclose(f);
+            return -1;
+        }
+    }
+    reset_reason_max = index;
+    reset_reason_inited = true;
+
+    fclose(f);
+    return 0;
+}
+
+char *get_reset_reason(int index)
+{
+	if (!reset_reason_inited && parse_reason_enum())
+		return NULL;
+	if (index <= 0 || index > reset_reason_max)
+		return NULL;
+
+	return reset_reasons[index];
+}
+
+const char *get_tcp_state_str(unsigned char state) {
+    if (state < 0 || state >= sizeof(tcp_state_str) / sizeof(tcp_state_str[0])) {
+        return "UNKNOWN";
+    }
+    return tcp_state_str[state];
+}

--- a/src/rstreason.h
+++ b/src/rstreason.h
@@ -1,0 +1,10 @@
+#ifndef _H_TCP_RESET_REASON
+#define _H_TCP_RESET_REASON
+
+#include <stdbool.h>
+
+char *get_reset_reason(int index);
+bool reset_reason_support();
+const char *get_tcp_state_str(unsigned char state);
+
+#endif

--- a/src/trace.c
+++ b/src/trace.c
@@ -9,6 +9,7 @@
 #include "trace.h"
 #include "analysis.h"
 #include "dropreason.h"
+#include "rstreason.h"
 
 const char *cond_pre = "verlte() { [ \"$1\" = \"$2\" ] && echo 0 && return; "
 		       "[ \"$1\" = \"$(/bin/echo -e \"$1\\n$2\" | sort -V | head -n1)\" ] "
@@ -494,6 +495,11 @@ static int trace_prepare_args()
 		bpf_args->drop_reason = true;
 		trace_ctx.drop_reason = true;
 		get_drop_reason(1);
+	}
+
+	if (reset_reason_support()) {
+		trace_ctx.reset_reason = true;
+		get_reset_reason(1);
 	}
 
 	if (bpf_args->rate_limit && (trace_ctx.mode_mask & TRACE_MODE_BPF_CTX_MASK)) {

--- a/src/trace.h
+++ b/src/trace.h
@@ -159,6 +159,8 @@ typedef struct {
 	bool		skip_last;
 	bool		trace_clone;
 	struct bpf_object *obj;
+	/* if reset reason feature is supported */
+	bool 		reset_reason;
 } trace_context_t;
 
 #define TRACE_HAS_ANALYZER(trace, name) IS_ANALYZER(trace->analyzer, name)

--- a/src/trace.yaml
+++ b/src/trace.yaml
@@ -338,8 +338,20 @@ children:
     - tcp_v6_rcv:0
     - tcp_filter:1
     - tcp_child_process:2
-    - tcp_v4_send_reset:1
-    - tcp_v6_send_reset:1
+    - name: tcp_v4_send_reset:1/0
+      custom: 1
+      analyzer: reset
+      rules:
+      - exp: any
+        level: error
+        msg: connection reset initiated by transport layer (TCP stack, skb)
+    - name: tcp_v6_send_reset:1/0
+      custom: 1
+      analyzer: reset
+      rules:
+      - exp: any
+        level: error
+        msg: connection reset initiated by transport layer (TCP stack, skb)
     - tcp_v4_do_rcv:1
     - tcp_v6_do_rcv:1
     - tcp_rcv_established:1/0
@@ -454,7 +466,13 @@ children:
         level: info
         msg: TCP socket is closed
     - *tcp_rcv_state_process
-    - tcp_send_active_reset/0
+    - name: tcp_send_active_reset/0
+      custom: 1
+      analyzer: reset
+      rules:
+      - exp: any
+        level: error
+        msg: connection reset initiated by application (active close, sk)
     - name: tcp_ack_update_rtt/0
       custom: 1
       analyzer: rtt


### PR DESCRIPTION
This commit introduces support for tracking TCP reset reasons in nettrace.

Implement detection of kernel support for reset reasons，parse available reset reasons from the kernel and enabled retrieval by index.

Develop eBPF programs that attaches kprobes to the following kernel functions: `tcp_v4_send_reset()`, `tcp_v6_send_reset()`, `tcp_send_active_reset()`

Create a corresponding reset analyzer to process and interpret reset events.

Update `trace.yaml` to integrate the reset analyzer, facilitating the capture and output of reset reasons alongside TCP state information.