### PR TITLE
add extra histogram bucket for values >= 65536

### DIFF
--- a/src/progs/core.c
+++ b/src/progs/core.c
@@ -174,8 +174,8 @@ static __always_inline void update_stats_log(u32 val)
 {
 	u32 key = 0, i = 0, tmp = 2;
 
-	#pragma clang loop unroll_count(16)
-	for (; i < 16; i++) {
+	#pragma clang loop unroll_count(LAST_STATS_BUCKET)
+	for (; i < LAST_STATS_BUCKET; i++) {
 		if (val < tmp)
 			break;
 		tmp <<= 1;

--- a/src/progs/shared.h
+++ b/src/progs/shared.h
@@ -199,6 +199,8 @@ enum rule_type {
 };
 
 #define MAX_RULE_COUNT	8
+#define MAX_STATS_BUCKETS 17
+#define LAST_STATS_BUCKET (MAX_STATS_BUCKETS - 1)
 typedef struct {
 	int expected[MAX_RULE_COUNT];
 	int op[MAX_RULE_COUNT];


### PR DESCRIPTION
https://github.com/OpenCloudOS/nettrace/issues/149

将延迟分布直方图从 16 个桶扩展为 17 个桶，新增范围 ">=65536"。
